### PR TITLE
add an `image_file` driver for development

### DIFF
--- a/inkycal/display/drivers/image_file.py
+++ b/inkycal/display/drivers/image_file.py
@@ -1,0 +1,17 @@
+# Display resolution
+EPD_WIDTH       = 800
+EPD_HEIGHT      = 480
+
+class EPD:
+    def init(self):
+        pass
+
+    def display(self, image):
+        image.save('display_image.png')
+
+    def getbuffer(self, image):
+        image.save('getbuffer_image.png')
+        return image
+
+    def sleep(self):
+        pass


### PR DESCRIPTION
The driver just writes images to files. This makes it possible to test without an e-ink display.