### PR TITLE
fix an issue with im_colour parameter missing

### DIFF
--- a/inkycal/display/display.py
+++ b/inkycal/display/display.py
@@ -44,7 +44,7 @@ class Display:
         except FileNotFoundError:
             raise Exception('SPI could not be found. Please check if SPI is enabled')
 
-    def render(self, im_black: Image, im_colour:Image or None) -> None:
+    def render(self, im_black: Image, im_colour:Image or None=None) -> None:
         """Renders an image on the selected E-Paper display.
 
         Initlializes the E-Paper display, sends image data and executes command


### PR DESCRIPTION
This fixes an issue where im_colour, a required parameter of the rendering function on the display was missing on black-white display. See #290 for more details.