### PR TITLE
fix not-updating problem

### DIFF
--- a/inkycal/display/drivers/epdconfig.py
+++ b/inkycal/display/drivers/epdconfig.py
@@ -107,21 +107,21 @@ class RaspberryPi:
         self.SPI.mode = 0b00
         return 0
 
-    def module_exit(self):
+    def module_exit(self, cleanup=False):
         logger.debug("spi end")
         self.SPI.close()
 
         self.GPIO_RST_PIN.off()
         self.GPIO_DC_PIN.off()
         self.GPIO_PWR_PIN.off()
-
-        self.GPIO_RST_PIN.close()
-        self.GPIO_DC_PIN.close()
-        # self.GPIO_CS_PIN.close()
-        self.GPIO_PWR_PIN.close()
-        self.GPIO_BUSY_PIN.close()
-
         logger.debug("close 5V, Module enters 0 power consumption ...")
+
+        if cleanup:
+            self.GPIO_RST_PIN.close()
+            self.GPIO_DC_PIN.close()
+            # self.GPIO_CS_PIN.close()
+            self.GPIO_PWR_PIN.close()
+            self.GPIO_BUSY_PIN.close()
 
 
 class JetsonNano:


### PR DESCRIPTION
This fixes an issue after a driver update where Inkycal would only run for the first run, but not continue rendering images. Cause was an error in the waveshare driver code