### PR TITLE
Feature/agenda-module-aesthetic-changes

### DIFF
--- a/inkycal/modules/inkycal_agenda.py
+++ b/inkycal/modules/inkycal_agenda.py
@@ -152,7 +152,7 @@ class Agenda(inkycal_module):
 
             time_width = int(max([self.font.getlength(
                 events['begin'].format(self.time_format, locale=self.language))
-                for events in upcoming_events]))
+                for events in upcoming_events]) + 10)
             logger.debug(f'time_width: {time_width}')
 
             # Calculate x-pos for time

--- a/inkycal/modules/inkycal_agenda.py
+++ b/inkycal/modules/inkycal_agenda.py
@@ -152,7 +152,7 @@ class Agenda(inkycal_module):
 
             time_width = int(max([self.font.getlength(
                 events['begin'].format(self.time_format, locale=self.language))
-                for events in upcoming_events]) * 1.2)
+                for events in upcoming_events]))
             logger.debug(f'time_width: {time_width}')
 
             # Calculate x-pos for time
@@ -160,7 +160,7 @@ class Agenda(inkycal_module):
             logger.debug(f'x-time: {x_time}')
 
             # Find out how much space is left for event titles
-            event_width = im_width - time_width - int(date_width/3)
+            event_width = im_width - time_width 
             logger.debug(f'width for events: {event_width}')
 
             # Calculate x-pos for event titles
@@ -201,16 +201,16 @@ class Agenda(inkycal_module):
                     # Check if event is all day, if not, add the time
                     if not parser.all_day(_):
                         write(im_black, (x_time, line_pos[cursor][1]),
-                              (time_width, line_height), time+" ",
+                              (time_width, line_height), time,
                               font=self.font, alignment='right')
                     if parser.all_day(_):
                         write(im_black, (x_time, line_pos[cursor][1]),
-                              (time_width, line_height), "all day ",
+                              (time_width, line_height), "all day",
                               font=self.font, alignment='right')
 
                     write(im_black, (x_event, line_pos[cursor][1]),
                           (event_width, line_height),
-                          '• ' + title, font=self.font, alignment='left')
+                          ' • ' + title, font=self.font, alignment='left')
                     cursor += 1
 
         # If no events were found, write only dates and lines

--- a/inkycal/modules/inkycal_agenda.py
+++ b/inkycal/modules/inkycal_agenda.py
@@ -201,8 +201,13 @@ class Agenda(inkycal_module):
                     # Check if event is all day, if not, add the time
                     if not parser.all_day(_):
                         write(im_black, (x_time, line_pos[cursor][1]),
-                              (time_width, line_height), time,
-                              font=self.font, alignment='left')
+                              (time_width, line_height), time+" ",
+                              font=self.font, alignment='right')
+                    # Check if event is all day, if it is, add "all day" where time would be
+                    if parser.all_day(_):
+                        write(im_black, (x_time, line_pos[cursor][1]),
+                              (time_width, line_height), "all day ",
+                              font=self.font, alignment='right')
 
                     write(im_black, (x_event, line_pos[cursor][1]),
                           (event_width, line_height),

--- a/inkycal/modules/inkycal_agenda.py
+++ b/inkycal/modules/inkycal_agenda.py
@@ -152,7 +152,7 @@ class Agenda(inkycal_module):
 
             time_width = int(max([self.font.getlength(
                 events['begin'].format(self.time_format, locale=self.language))
-                for events in upcoming_events]+[self.font.getlength("all day")]))
+                for events in upcoming_events]))
             logger.debug(f'time_width: {time_width}')
 
             # Calculate x-pos for time

--- a/inkycal/modules/inkycal_agenda.py
+++ b/inkycal/modules/inkycal_agenda.py
@@ -156,15 +156,15 @@ class Agenda(inkycal_module):
             logger.debug(f'time_width: {time_width}')
 
             # Calculate x-pos for time
-            x_time = date_width
+            x_time = int(date_width/3)
             logger.debug(f'x-time: {x_time}')
 
             # Find out how much space is left for event titles
-            event_width = im_width - time_width - date_width
+            event_width = im_width - time_width - int(date_width/3)
             logger.debug(f'width for events: {event_width}')
 
             # Calculate x-pos for event titles
-            x_event = date_width + time_width
+            x_event = int(date_width/3) + time_width
             logger.debug(f'x-event: {x_event}')
 
             # Merge list of dates and list of events

--- a/inkycal/modules/inkycal_agenda.py
+++ b/inkycal/modules/inkycal_agenda.py
@@ -132,7 +132,7 @@ class Agenda(inkycal_module):
 
         # Sort events by beginning time
         parser.sort()
-        # parser.show_events()
+        print(parser.show_events())
 
         # Set the width for date, time and event titles
         date_width = int(max([self.font.getlength(
@@ -203,7 +203,6 @@ class Agenda(inkycal_module):
                         write(im_black, (x_time, line_pos[cursor][1]),
                               (time_width, line_height), time+" ",
                               font=self.font, alignment='right')
-                    # Check if event is all day, if it is, add "all day" where time would be
                     if parser.all_day(_):
                         write(im_black, (x_time, line_pos[cursor][1]),
                               (time_width, line_height), "all day ",

--- a/inkycal/modules/inkycal_agenda.py
+++ b/inkycal/modules/inkycal_agenda.py
@@ -137,7 +137,7 @@ class Agenda(inkycal_module):
         # Set the width for date, time and event titles
         date_width = int(max([self.font.getlength(
             dates['begin'].format(self.date_format, locale=self.language))
-            for dates in agenda_events]) * 1.2)
+            for dates in agenda_events]))
         logger.debug(f'date_width: {date_width}')
 
         # Calculate positions for each line
@@ -152,7 +152,7 @@ class Agenda(inkycal_module):
 
             time_width = int(max([self.font.getlength(
                 events['begin'].format(self.time_format, locale=self.language))
-                for events in upcoming_events]))
+                for events in upcoming_events]+[self.font.getlength("all day")]))
             logger.debug(f'time_width: {time_width}')
 
             # Calculate x-pos for time

--- a/inkycal/modules/inkycal_agenda.py
+++ b/inkycal/modules/inkycal_agenda.py
@@ -132,7 +132,7 @@ class Agenda(inkycal_module):
 
         # Sort events by beginning time
         parser.sort()
-        print(parser.show_events())
+        # parser.show_events()
 
         # Set the width for date, time and event titles
         date_width = int(max([self.font.getlength(


### PR DESCRIPTION
1. Moves the time and event titles further to the left, to allow more space for event titles. 
* Events often have long titles that get cut off, especially if users increase font size

2. Right aligns the time
* I feel like it looks better aesthetically to have the end of the time and the beginning of the event be right next to each other. 
* I also added a space before the dot to match the space after

3. Added "all day" to replace a missing time marker
* this may need to be translated, but I'm not sure how to do that. is there a better way to do it than just make a list of the words "all day" in every language? maybe the date module already has this built in?

Aesthetic changes look like this:
https://photos.app.goo.gl/Ti9gbmB6kwJw7Gj6A
