### PR TITLE
Hotfix/#357

### DIFF
--- a/inkycal/display/drivers/10_in_3.py
+++ b/inkycal/display/drivers/10_in_3.py
@@ -36,8 +36,8 @@ class EPD:
     def getbuffer(self, image):
         """ad-hoc"""
         image = image.rotate(90, expand=True).transpose(Image.FLIP_LEFT_RIGHT)
-        image.convert('RGB').save(os.path.join(settings.IMAGE_FOLDER, 'canvas.bmp'), 'BMP')
-        command = f'sudo {settings.PARALLEL_DRIVER_PATH}/epd -{settings.VCOM} 0 {settings.IMAGE_FOLDER + "canvas.bmp"}'
+        image.convert("RGB").save(os.path.join(settings.IMAGE_FOLDER, "canvas.bmp"), "BMP")
+        command = f'sudo {settings.PARALLEL_DRIVER_PATH}/epd -{settings.VCOM} 0 {os.path.join(settings.IMAGE_FOLDER, "canvas.bmp")}'
         print(command)
         return command
 

--- a/inkycal/display/drivers/7_in_8.py
+++ b/inkycal/display/drivers/7_in_8.py
@@ -34,8 +34,8 @@ class EPD:
     def getbuffer(self, image):
         """ad-hoc"""
         image = image.rotate(90, expand=True)
-        image.convert('RGB').save(os.path.join(settings.IMAGE_FOLDER, 'canvas.bmp'), 'BMP')
-        command = f'sudo {settings.PARALLEL_DRIVER_PATH}/epd -{settings.VCOM} 0 {settings.IMAGE_FOLDER + "canvas.bmp"}'
+        image.convert("RGB").save(os.path.join(settings.IMAGE_FOLDER, "canvas.bmp"), 'BMP')
+        command = f'sudo {settings.PARALLEL_DRIVER_PATH}/epd -{settings.VCOM} 0 {os.path.join(settings.IMAGE_FOLDER, "canvas.bmp")}'
         print(command)
         return command
 

--- a/inkycal/display/drivers/9_in_7.py
+++ b/inkycal/display/drivers/9_in_7.py
@@ -2,6 +2,7 @@
 9.7" driver class
 Copyright by aceinnolab
 """
+import os
 from subprocess import run
 
 from inkycal.settings import Settings
@@ -10,10 +11,7 @@ from inkycal.settings import Settings
 EPD_WIDTH = 1200
 EPD_HEIGHT = 825
 
-
 settings = Settings()
-
-command = f'sudo {settings.PARALLEL_DRIVER_PATH}/epd -{settings.VCOM} 0 {settings.IMAGE_FOLDER + "canvas.bmp"}'
 
 
 class EPD:
@@ -36,8 +34,8 @@ class EPD:
     def getbuffer(self, image):
         """ad-hoc"""
         image = image.rotate(90, expand=True)
-        image.convert('RGB').save(settings.IMAGE_FOLDER + 'canvas.bmp', 'BMP')
-        command = f'sudo {settings.PARALLEL_DRIVER_PATH}/epd -{settings.VCOM} 0 {settings.IMAGE_FOLDER + "canvas.bmp"}'
+        image.convert("RGB").save(os.path.join(settings.IMAGE_FOLDER, "canvas.bmp"), "BMP")
+        command = f'sudo {settings.PARALLEL_DRIVER_PATH}/epd -{settings.VCOM} 0 {os.path.join(settings.IMAGE_FOLDER, "canvas.bmp")}'
         print(command)
         return command
 

--- a/inkycal/main.py
+++ b/inkycal/main.py
@@ -137,11 +137,8 @@ class Inkycal:
             except:
                 logger.exception(f"Exception: {traceback.format_exc()}.")
 
-        # Path to store images
-        self.image_folder = settings.IMAGE_FOLDER
-
         # Remove old hashes
-        self._remove_hashes(self.image_folder)
+        self._remove_hashes(settings.IMAGE_FOLDER)
 
         # set up cache
         if not os.path.exists(os.path.join(settings.CACHE_PATH, CACHE_NAME)):
@@ -352,11 +349,11 @@ class Inkycal:
                 self._calibration_check()
                 if self._calibration_state:
                     # After calibration, we have to forcefully rewrite the screen
-                    self._remove_hashes(self.image_folder)
+                    self._remove_hashes(settings.IMAGE_FOLDER)
 
                 if self.supports_colour:
-                    im_black = Image.open(f"{self.image_folder}canvas.png")
-                    im_colour = Image.open(f"{self.image_folder}canvas_colour.png")
+                    im_black = Image.open(os.path.join(settings.IMAGE_FOLDER, "canvas.png"))
+                    im_colour = Image.open(os.path.join(settings.IMAGE_FOLDER, "canvas_colour.png"))
 
                     # Flip the image by 180° if required
                     if self.settings['orientation'] == 180:
@@ -365,8 +362,8 @@ class Inkycal:
 
                     # Render the image on the display
                     if not self.settings.get('image_hash', False) or self._needs_image_update([
-                        (f"{self.image_folder}/canvas.png.hash", im_black),
-                        (f"{self.image_folder}/canvas_colour.png.hash", im_colour)
+                        (f"{settings.IMAGE_FOLDER}/canvas.png.hash", im_black),
+                        (f"{settings.IMAGE_FOLDER}/canvas_colour.png.hash", im_colour)
                     ]):
                         display.render(im_black, im_colour)
 
@@ -379,7 +376,7 @@ class Inkycal:
                         im_black = upside_down(im_black)
 
                     if not self.settings.get('image_hash', False) or self._needs_image_update([
-                        (f"{self.image_folder}/canvas.png.hash", im_black), ]):
+                        (f"{settings.IMAGE_FOLDER}/canvas.png.hash", im_black), ]):
                         display.render(im_black)
 
             logger.info(f'\nNo errors since {self.counter} display updates')
@@ -415,8 +412,8 @@ class Inkycal:
         returns the merged image
         """
 
-        im1_path = os.path.join(settings.image_folder, "canvas.png")
-        im2_path = os.path.join(settings.image_folder, "canvas_colour.png")
+        im1_path = os.path.join(settings.IMAGE_FOLDER, "canvas.png")
+        im2_path = os.path.join(settings.IMAGE_FOLDER, "canvas_colour.png")
 
         # If there is an image for black and colour, merge them
         if os.path.exists(im1_path) and os.path.exists(im2_path):
@@ -454,8 +451,8 @@ class Inkycal:
         for number in range(1, self._module_number):
 
             # get the path of the current module's generated images
-            im1_path = f"{self.image_folder}module{number}_black.png"
-            im2_path = f"{self.image_folder}module{number}_colour.png"
+            im1_path = os.path.join(settings.IMAGE_FOLDER, f"module{number}_black.png")
+            im2_path = os.path.join(settings.IMAGE_FOLDER, f"module{number}_colour.png")
 
             # Check if there is an image for the black band
             if os.path.exists(im1_path):
@@ -525,8 +522,8 @@ class Inkycal:
             im_black = self._optimize_im(im_black)
             im_colour = self._optimize_im(im_colour)
 
-        im_black.save(self.image_folder + 'canvas.png', 'PNG')
-        im_colour.save(self.image_folder + 'canvas_colour.png', 'PNG')
+        im_black.save(os.path.join(settings.IMAGE_FOLDER, "canvas.png"), "PNG")
+        im_colour.save(os.path.join(settings.IMAGE_FOLDER, "canvas_colour.png"), 'PNG')
 
         # Additionally, combine the two images with color
         def clear_white(img):
@@ -614,8 +611,8 @@ class Inkycal:
             black, colour = module.generate_image()
             if self.show_border:
                 draw_border_2(im=black, xy=(1, 1), size=(black.width - 2, black.height - 2), radius=5)
-            black.save(f"{self.image_folder}module{number}_black.png", "PNG")
-            colour.save(f"{self.image_folder}module{number}_colour.png", "PNG")
+            black.save(os.path.join(settings.IMAGE_FOLDER, f"module{number}_black.png"), "PNG")
+            colour.save(os.path.join(settings.IMAGE_FOLDER, f"module{number}_colour.png"), "PNG")
             return True
         except Exception:
             logger.exception(f"Error in module {number}!")

--- a/inkycal/settings.py
+++ b/inkycal/settings.py
@@ -15,6 +15,6 @@ class Settings:
     INKYCAL_LOG_PATH = os.path.join(LOG_PATH, "inkycal.log")
     FONT_PATH = os.path.join(basedir, "../fonts")
     IMAGE_FOLDER = os.path.join(basedir, "../image_folder")
-    PARALLEL_DRIVER_PATH = os.path.join(basedir, "inkycal", "display", "drivers", "parallel_drivers")
+    PARALLEL_DRIVER_PATH = os.path.join(basedir, "display", "drivers", "parallel_drivers")
     TEMPORARY_FOLDER = os.path.join(basedir, "tmp")
     VCOM = "2.0"


### PR DESCRIPTION
This fixes an issue for parallel displays not being able to find the image files generated by Inkycal.
Also fixes an issue where the settings class had no attribute image_folder, which should have been in capital_letters.

Special thanks to Martin for their help with testing the fix!
