### PR TITLE
Add apt update command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Run the following steps to install Inkycal. Do **not** use sudo for this, except
 
 ```bash
 # Raspberry Pi specific section start
+sudo apt update
 sudo apt-get install git zlib1g libjpeg-dev libatlas-base-dev rustc libopenjp2-7 python-dev-is-python3 scons libssl-dev python3-venv python3-pip git libfreetype6-dev wkhtmltopdf libopenblas-dev 
 git clone https://github.com/WiringPi/WiringPi
 cd WiringPi


### PR DESCRIPTION
The README suggests that the user download an old version of Raspbian. On this version, a `sudo apt update` is required before installing packages from apt-get. Otherwise, some of the packages 404 because the package servers changed branch names:
```
htwyford@inkycal:~ $ sudo apt update
Get:1 http://archive.raspberrypi.org/debian bullseye InRelease [39.0 kB]
Get:2 http://raspbian.raspberrypi.org/raspbian bullseye InRelease [15.0 kB]
Get:3 http://archive.raspberrypi.org/debian bullseye/main armhf Packages [321 kB]
Get:4 http://raspbian.raspberrypi.org/raspbian bullseye/main armhf Packages [13.2 MB]
Get:5 http://raspbian.raspberrypi.org/raspbian bullseye/non-free armhf Packages [106 kB]
Fetched 13.7 MB in 14s (990 kB/s)
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
109 packages can be upgraded. Run 'apt list --upgradable' to see them.
N: Repository 'http://archive.raspberrypi.org/debian bullseye InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
N: Repository 'http://raspbian.raspberrypi.org/raspbian bullseye InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
```