### PR TITLE
Feature/#390

### DIFF
--- a/inkycal/display/drivers/image_file_7_in_5_v3_colour.py
+++ b/inkycal/display/drivers/image_file_7_in_5_v3_colour.py
@@ -1,0 +1,21 @@
+"""Image file driver for testing"""
+
+# Display resolution
+EPD_WIDTH = 880
+EPD_HEIGHT = 528
+
+
+class EPD:
+    def init(self):
+        pass
+
+    def display(self, image,image_red):
+        image.save('display_image.png')
+        image_red.save('display_image_red.png')
+
+    def getbuffer(self, image):
+        image.save('getbuffer_image.png')
+        return image
+
+    def sleep(self):
+        pass

--- a/inkycal/display/supported_models.py
+++ b/inkycal/display/supported_models.py
@@ -20,4 +20,5 @@ supported_models = {
     "epd_7_in_5_v3_colour": (880, 528),
     "epd_5_in_83": (600, 448),
     "image_file": (800, 480),
+    "image_file_7_in_5_v3_colour": (880, 528)
 }

--- a/scratpad/settings_180_border.json
+++ b/scratpad/settings_180_border.json
@@ -1,0 +1,36 @@
+{
+    "model": "image_file_7_in_5_v3_colour",
+    
+    "frame_border_width_left" : 10,
+    "frame_border_width_right" : 10,
+    "frame_border_height_top" : 20,
+    "frame_border_height_bottom" : 20,
+
+        "update_interval": 60,
+        "orientation": 180,
+        "info_section": true,
+        "info_section_height": 20,
+        "border_around_modules": true,
+        "modules": [
+            {
+                "position": 1,
+                "name": "Xkcd",
+                "config": {
+                    "size": [
+                        508,
+                        820
+                    ],
+                    "mode": "latest",
+                    "palette": "bw",
+                    "alt": "no",
+                    "filter": "no",
+                    "padding_x": 10,
+                    "padding_y": 5,
+                    "fontsize": 12,
+                    "language": "en"
+                }
+            }
+        ],
+        "language": "en",
+        "calibration_hours": []
+    }

--- a/scratpad/settings_border.json
+++ b/scratpad/settings_border.json
@@ -1,0 +1,36 @@
+{
+    "model": "image_file_7_in_5_v3_colour",
+    
+    "frame_border_width_left" : 10,
+    "frame_border_width_right" : 20,
+    "frame_border_height_top" : 40,
+    "frame_border_height_bottom" : 80,
+
+        "update_interval": 60,
+        "orientation": 0,
+        "info_section": true,
+        "info_section_height": 20,
+        "border_around_modules": true,
+        "modules": [
+            {
+                "position": 1,
+                "name": "Xkcd",
+                "config": {
+                    "size": [
+                        498,
+                        770
+                    ],
+                    "mode": "latest",
+                    "palette": "bw",
+                    "alt": "no",
+                    "filter": "no",
+                    "padding_x": 10,
+                    "padding_y": 5,
+                    "fontsize": 12,
+                    "language": "en"
+                }
+            }
+        ],
+        "language": "en",
+        "calibration_hours": []
+    }

--- a/scratpad/settings_border_0.json
+++ b/scratpad/settings_border_0.json
@@ -1,0 +1,36 @@
+{
+    "model": "image_file_7_in_5_v3_colour",
+
+    "frame_border_width_left" : 0,
+    "frame_border_width_right" : 0,
+    "frame_border_height_top" : 0,
+    "frame_border_height_bottom" : 0,
+
+    "update_interval": 60,
+    "orientation": 0,
+    "info_section": true,
+    "info_section_height": 20,
+    "border_around_modules": true,
+    "modules": [
+        {
+            "position": 1,
+            "name": "Xkcd",
+            "config": {
+                "size": [
+                    528,
+                    860
+                ],
+                "mode": "latest",
+                "palette": "bw",
+                "alt": "no",
+                "filter": "no",
+                "padding_x": 10,
+                "padding_y": 5,
+                "fontsize": 12,
+                "language": "en"
+            }
+        }
+    ],
+    "language": "en",
+    "calibration_hours": []
+}

--- a/scratpad/settings_no_border.json
+++ b/scratpad/settings_no_border.json
@@ -1,0 +1,30 @@
+{
+        "model": "image_file_7_in_5_v3_colour",
+        "update_interval": 60,
+        "orientation": 0,
+        "info_section": true,
+        "info_section_height": 20,
+        "border_around_modules": true,
+        "modules": [
+            {
+                "position": 1,
+                "name": "Xkcd",
+                "config": {
+                    "size": [
+                        528,
+                        860
+                    ],
+                    "mode": "latest",
+                    "palette": "bw",
+                    "alt": "no",
+                    "filter": "no",
+                    "padding_x": 10,
+                    "padding_y": 5,
+                    "fontsize": 12,
+                    "language": "en"
+                }
+            }
+        ],
+        "language": "en",
+        "calibration_hours": []
+    }

--- a/scratpad/test_feature_390.py
+++ b/scratpad/test_feature_390.py
@@ -1,0 +1,59 @@
+import os, sys
+import shutil
+import asyncio
+
+if "." not in sys.path :    sys.path.append(".")
+from inkycal import Inkycal
+
+CWD = os.getcwd()
+IMAGE_FOLDER = f"{CWD}/image_folder"
+SCRATCHPAD_DIR = os.path.abspath(os.path.dirname(__file__))
+IMAGES_TO_ARCHIVE = ["frame_bw.png", "full-screen.png" ]
+
+SETTINGS_PATHS = [
+        { "label" : "no_border",    "settings_path" : f"{SCRATCHPAD_DIR}/settings_no_border.json"},
+        { "label" : "border_0",     "settings_path" : f"{SCRATCHPAD_DIR}/settings_border_0.json"},
+        { "label" : "border",       "settings_path" : f"{SCRATCHPAD_DIR}/settings_border.json"},
+        { "label" : "180_border",   "settings_path" : f"{SCRATCHPAD_DIR}/settings_180_border.json"}
+    ]
+
+# remove images from previous runs
+for png_file in [f for f in os.listdir(SCRATCHPAD_DIR) if f.endswith(".png")] :
+    os.remove(f"{SCRATCHPAD_DIR}/{png_file}")
+
+# save the full display qnd the visible frame for all settings.json above
+for settings_info in SETTINGS_PATHS :
+    label, settings_path = settings_info["label"], settings_info["settings_path"]
+
+    inkycal = Inkycal(settings_path, render=True)
+    asyncio.get_event_loop().run_until_complete( inkycal.run(run_once=True))
+
+    # copy the rendered images to this folder
+    for f in IMAGES_TO_ARCHIVE:
+        shutil.copyfile(f"{IMAGE_FOLDER}/{f}", f"{SCRATCHPAD_DIR}/{label}_{f}")
+
+    # print a bunch of data to check the settings.json is OK and the frame data makes sense
+    print("##########################################################################")
+    print(f"prefix '{label}' : ")
+    print(f"Display :           size : {inkycal.Display.get_display_size(inkycal.settings['model'])}")
+    if "frame_border_width_left" in inkycal.settings :
+        print(f"Frame :             size : {inkycal.frame_size}")
+        print(f"Frame :  frame_border_width_left : {inkycal.settings['frame_border_width_left']}, frame_border_height_top :{inkycal.settings['frame_border_height_top']}")
+        print(f"      :  frame_border_width_right : {inkycal.settings['frame_border_width_right']}, frame_border_height_bottom :{inkycal.settings['frame_border_height_bottom']}")
+        print(f"Frame :  corner 1 : {inkycal.frame_coord[0]:>3},{inkycal.frame_coord[1]:>3}")
+        print(f"         corner 2 : {inkycal.frame_coord[2]:>3},{inkycal.frame_coord[3]:>3}")
+    else :
+        print(f"Frame :             no frame settings in the json ")
+    
+    total_module_height = 0
+    for m in inkycal.settings['modules']:
+        module_config = m["config"]
+        module_info = f"size {str(module_config.get('size','n/a')):>10}\tpadding {module_config.get('padding_x','n/a'):>3},{module_config.get('padding_y','n/a'):>3}"
+        total_module_height += module_config['size'][1]
+        print(f"\tmodule {m['name']:<10} : {module_info}")
+
+    print(f"\tmodule {'DEBUG':<10} : {inkycal.settings['info_section_height']} ({   inkycal.settings['info_section']})")
+    print(f"total height : {total_module_height} (debug height:{inkycal.settings['info_section_height']})")
+
+    
+    print("##########################################################################")


### PR DESCRIPTION
( my first PR ever on GitHub, hey... hope I did it right, let me know if otherwise... )

Reference :  [[[FEATURE]: defining borders around the content, rendering Inkycal on an area smaller than the full panel](https://github.com/aceinnolab/Inkycal/issues/390)](https://github.com/aceinnolab/Inkycal/issues/390)

This PR is made of 3 commits : 
- one is just adding a new color image-based panel "[image_file_7_in_5_v3_colour.py](https://github.com/pbarthelemy/Inkycal/blob/feature/%23390/inkycal/display/drivers/image_file_7_in_5_v3_colour.py)" : for testing purpose
- one for "unit" tests in a new scratch folder  [scratpad](https://github.com/pbarthelemy/Inkycal/blob/feature/%23390/scratpad/test_feature_390.py)
- *the actual code, an update to [main.py](https://github.com/pbarthelemy/Inkycal/blob/feature/%23390/inkycal/main.py)*

The tests in the scratpad : 
1. a settings.json without the new fields, to confirm backward compatibility : [settings_no_border.json](https://github.com/pbarthelemy/Inkycal/blob/feature/%23390/scratpad/settings_no_border.json)
2. a settings.json with the new fields but with all widths set at 0, to confirm the rendered images are the same as in previous versions : [settings_border_0.json](https://github.com/pbarthelemy/Inkycal/blob/feature/%23390/scratpad/settings_border_0.json)
3. a settings.json with  borders : [settings_border.json](https://github.com/pbarthelemy/Inkycal/blob/feature/%23390/scratpad/settings_border.json)
4. a settings.json with borders, with orientation st at 180 : [settings_180_border.json](https://github.com/pbarthelemy/Inkycal/blob/feature/%23390/scratpad/settings_180_border.json)

The needed change to the `web-ui` are not in this PR :
[settings.json - with new fields](https://github.com/pbarthelemy/Inkycal/blob/feature/%23390/scratpad/settings_border.json)
`    "frame_border_width_left" : 10,`
`    "frame_border_width_right" : 20,`
`    "frame_border_height_top" : 40,`
`    "frame_border_height_bottom" : 80,`