### PR TITLE
Increment matplotlib req  due to FreeType library compilation error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ identify==2.5.34
 idna==3.7
 kiwisolver==1.4.5
 lgpio==0.0.0.2
-matplotlib==3.7.1
+matplotlib==3.8.2
 multitasking==0.0.11
 nodeenv==1.8.0
 numpy==1.26.2


### PR DESCRIPTION
This is a compilation error when trying to build `matplotlib` from source. The issue is with the `FreeType` library compilation where the `Byte` type is not properly defined in the zlib headers. So, incrementing  `matplotlib` version that have better compatibility