### PR TITLE
Skipping resize if the image already correct size

### DIFF
--- a/inkycal/modules/inky_image.py
+++ b/inkycal/modules/inky_image.py
@@ -152,6 +152,13 @@ class Inkyimage:
                 logger.error("no height of width specified")
                 return
 
+            current_width, current_height = self.image.size
+
+            # Skip if dimensions are the same
+            if width == current_width and height == current_height:
+                logger.info(f"Image already correct size ({width}x{height}), skipping resize")
+                return
+
             image = self.image
 
             if width:


### PR DESCRIPTION
Skipping resize if the image already correct size:

```
17-08-2025 12:09:53 | inkycal.modules.inkycal_image |  INFO: Image size: (480, 800)
17-08-2025 12:09:53 | inkycal.modules.inky_image |  INFO: loading image from local path
17-08-2025 12:09:53 | inkycal.modules.inky_image |  INFO: loaded Image
17-08-2025 12:09:53 | inkycal.modules.inky_image |  INFO: removing alpha channel
17-08-2025 12:09:53 | inkycal.modules.inky_image |  INFO: removed transparency
17-08-2025 12:09:53 | inkycal.modules.inky_image |  INFO: image width greater than image height, flipping
17-08-2025 12:09:53 | inkycal.modules.inky_image |  INFO: Image already correct size (480x800), skipping resize
```