### PR TITLE
Fix displaying todoist task with due dates

### DIFF
--- a/inkycal/modules/inkycal_todoist.py
+++ b/inkycal/modules/inkycal_todoist.py
@@ -311,7 +311,7 @@ class Todoist(InkycalModule):
             # Parse date in local timezone to ensure correct comparison
             try:
                 due_date = (
-                    arrow.get(task.due.date, "YYYY-MM-DD").replace(tzinfo="local")
+                    arrow.get(task.due.date).replace(tzinfo="local")
                     if task.due
                     else None
                 )


### PR DESCRIPTION
I noticed that my todoist tasks with due dates weren't showing up on my page.

Running the script directly, all of them were returning warning about note being able to parse the timestamp.

After looking at the documentation, it looks like the API for todoist returns due dates as strings, but the Python sdk returns them as datetime object already.

This PR removes the string conversion in the arrow.get for the due date so they can be loaded correctly. 