### PR TITLE
Adding a 12.48" image file driver specification

### DIFF
--- a/inkycal/display/drivers/image_file_12_in_48.py
+++ b/inkycal/display/drivers/image_file_12_in_48.py
@@ -1,0 +1,20 @@
+"""Image file driver for testing (12.48 inch)"""
+
+# Display resolution
+EPD_WIDTH = 1304
+EPD_HEIGHT = 984
+
+
+class EPD:
+    def init(self):
+        pass
+
+    def display(self, image):
+        image.save('display_image.png')
+
+    def getbuffer(self, image):
+        image.save('getbuffer_image.png')
+        return image
+
+    def sleep(self):
+        pass

--- a/inkycal/display/supported_models.py
+++ b/inkycal/display/supported_models.py
@@ -20,4 +20,5 @@ supported_models = {
     "epd_7_in_5_v3_colour": (880, 528),
     "epd_5_in_83": (600, 448),
     "image_file": (800, 480),
+    "image_file_12_in_48": (1304, 984),
 }


### PR DESCRIPTION
Ace I'm starting to do a little development coding specific to enabling different layouts within 12.48" interfaces. I wanted to make it easier to test out development images with the larger 12.48" image size so I added a separate image model. Feel free to accept this PR if it's helpful for others to develop on larger screens!