### PR TITLE
fix: respect frame orientation in startup splashscreen

### DIFF
--- a/inky_run.py
+++ b/inky_run.py
@@ -78,6 +78,7 @@ def _show_startup_splash_if_needed() -> None:
         return
 
     try:
+        orientation = int(settings_data.get("orientation", 0))
         display = Display(model)
         display.render_startup_splash(
             title="Inkycal",
@@ -85,6 +86,7 @@ def _show_startup_splash_if_needed() -> None:
             title_font_size=88,
             version_font_size=30,
             line_gap=28,
+            orientation=orientation,
         )
         os.makedirs(os.path.dirname(flag_path), exist_ok=True)
         with open(flag_path, "w", encoding="utf-8") as marker:

--- a/inkycal/display/display.py
+++ b/inkycal/display/display.py
@@ -319,8 +319,16 @@ class Display:
         title_font_size: int = 88,
         version_font_size: int = 36,
         line_gap: int = 20,
+        orientation: int = 0,
     ) -> None:
-        """Render a two-line monochrome startup splash centered on screen."""
+        """Render a two-line monochrome startup splash centered on screen.
+
+        Args:
+            orientation (int):
+                Rotation angle in degrees to apply to the splash image before
+                rendering. Accepts ``0`` (no rotation) or ``180`` (upside-down).
+                Matches the ``orientation`` field in ``settings.json``.
+        """
         from PIL import ImageDraw, ImageFont
         from inkycal.utils.enums import FONTS
 
@@ -351,7 +359,10 @@ class Display:
         draw.text((title_x, title_y), title, fill="black", font=title_font)
         draw.text((version_x, version_y), version, fill="black", font=version_font)
 
-        image_colour = Image.new("1", (width, height), "white")
+        if orientation:
+            image_bw = image_bw.rotate(orientation, expand=True)
+
+        image_colour = Image.new("1", image_bw.size, "white")
         self.render(image_bw, image_colour)
 
 


### PR DESCRIPTION
## Summary

The startup splashscreen was not respecting the `orientation` setting from `settings.json`, so on frames mounted upside-down the splash would appear inverted while all other content rendered correctly.

## Changes

- **`inkycal/display/display.py`**: `render_startup_splash` now accepts an `orientation: int = 0` parameter. After drawing the text, the image is rotated by that angle before rendering.
- **`inky_run.py`**: `_show_startup_splash_if_needed` reads `settings['orientation']` (defaulting to `0` if absent) and forwards it to `render_startup_splash`.

This is consistent with how `main.py` already handles orientation for the main canvas.