### PR TITLE
fix: update asset URLs to hosted domain after git history cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-    <img src="https://raw.githubusercontent.com/aceinnolab/Inkycal/assets/Repo/logo.png" width="900" alt="aceinnolab logo">
+    <img src="https://inkycal.aceinnolab.com/static/images/inkycal_logo.png" width="900" alt="aceinnolab logo">
 </p>
 <p align="center">
     <img src="https://github.com/aceinnolab/Inkycal/blob/c1c274878ba81ddaee6186561e6ea892da54cd6a/Repo/inkycal-featured-gif.gif" width="900" alt="featured-image">

--- a/tests/test_inkycal_slideshow.py
+++ b/tests/test_inkycal_slideshow.py
@@ -18,8 +18,8 @@ if not os.path.exists("tmp"):
     os.mkdir("tmp")
 
 im_urls = [
-    "https://github.com/aceinnolab/Inkycal/raw/assets/Repo/coffee.png",
-    "https://github.com/aceinnolab/Inkycal/raw/assets/Repo/coffee.png"
+    "https://inkycal.aceinnolab.com/static/images/inkycal_logo.png",
+    "https://inkycal.aceinnolab.com/static/images/inkycal_logo.png"
 ]
 
 for count, url in enumerate(im_urls):


### PR DESCRIPTION
## Summary

During the large-file git history purge, the `Repo/` folder was removed from history. This broke raw.githubusercontent.com URLs that pointed to those assets.

## Changes
- **`README.md`**: Logo image URL updated to `inkycal.aceinnolab.com` hosted version
- **`tests/test_inkycal_slideshow.py`**: Test image URLs updated to hosted equivalents