### PR TITLE
Install WiringPi in installer for 12.48 display

### DIFF
--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -179,6 +179,8 @@ cd bcm2835-1.71/
 sudo ./configure && sudo make && sudo make check && sudo make install
 ```
 
+If you use `python3 installer.py`, WiringPi is now installed automatically during `Install / Repair Inkycal`.
+
 ## Step 5 — Install Dependencies
 
 - Update system:

--- a/docs/docs/installer.md
+++ b/docs/docs/installer.md
@@ -36,6 +36,7 @@ The installer can:
 - create the `venv`
 - install or refresh Python dependencies
 - install or repair apt-side prerequisites when needed
+- install WiringPi from source (unconditionally on Linux, for 12.48" display compatibility)
 - use the PiWheels-friendly package flow already documented in the main installation guide
 
 ### Raspberry Pi Zero swap setup
@@ -158,4 +159,3 @@ The community is happy to help:
 
 - Discord: [https://discord.gg/sHYKeSM](https://discord.gg/sHYKeSM)
 - GitHub Issues: [https://github.com/aceinnolab/Inkycal/issues](https://github.com/aceinnolab/Inkycal/issues)
-

--- a/installer.py
+++ b/installer.py
@@ -24,6 +24,7 @@ except ImportError:  # pragma: no cover - non-POSIX only
 
 
 APT_PACKAGES_FILE = "apt_packages.txt"
+WIRINGPI_REPO_URL = "https://github.com/WiringPi/WiringPi"
 
 PIP_INDEX_ARGS = [
     "--index-url", "https://www.piwheels.org/simple",
@@ -326,6 +327,7 @@ def install_or_repair(ctx: InstallerContext) -> None:
     except Exception as error:
         print(f"Warning: apt dependency step failed: {error}")
 
+    install_wiringpi(ctx)
     setup_swap(ctx, prompt=True)
 
     if not ctx.venv_dir.exists():
@@ -346,6 +348,21 @@ def install_or_repair(ctx: InstallerContext) -> None:
 
     save_state(ctx, "install", "ok")
     print("Install/repair completed.")
+
+
+def install_wiringpi(ctx: InstallerContext) -> None:
+    if sys.platform != "linux":
+        print("Skipping WiringPi install on non-Linux host.")
+        return
+
+    print('Installing WiringPi (needed for 12.48" display compatibility)...')
+    with tempfile.TemporaryDirectory(prefix="inkycal-wiringpi-") as temp_dir:
+        clone_path = Path(temp_dir) / "WiringPi"
+        result = run_command(["git", "clone", WIRINGPI_REPO_URL, str(clone_path)])
+        print_command_result(result)
+        result = run_command(["./build"], cwd=clone_path, use_sudo=True)
+        print_command_result(result)
+    save_state(ctx, "wiringpi", "ok")
 
 
 def update_inkycal(ctx: InstallerContext) -> None:

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,6 +1,7 @@
 """Tests for installer helpers."""
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import installer
 
@@ -19,3 +20,42 @@ def test_render_service_contents_has_expected_fields():
     assert "ExecStart=" in service
     assert "INKYCAL_WEBUI_HOST=0.0.0.0" in webui
 
+
+def test_install_wiringpi_skips_on_non_linux(monkeypatch, capsys):
+    ctx = installer.detect_context(Path(__file__).resolve().parent.parent)
+    calls = []
+
+    def fake_run_command(*args, **kwargs):
+        calls.append((args, kwargs))
+        return SimpleNamespace(stdout="", stderr="")
+
+    monkeypatch.setattr(installer.sys, "platform", "darwin")
+    monkeypatch.setattr(installer, "run_command", fake_run_command)
+
+    installer.install_wiringpi(ctx)
+
+    assert calls == []
+    assert "Skipping WiringPi install on non-Linux host." in capsys.readouterr().out
+
+
+def test_install_wiringpi_runs_clone_and_build(monkeypatch):
+    ctx = installer.detect_context(Path(__file__).resolve().parent.parent)
+    run_calls = []
+    saved_state = []
+
+    def fake_run_command(command, **kwargs):
+        run_calls.append((command, kwargs))
+        return SimpleNamespace(stdout="", stderr="")
+
+    monkeypatch.setattr(installer.sys, "platform", "linux")
+    monkeypatch.setattr(installer, "run_command", fake_run_command)
+    monkeypatch.setattr(installer, "save_state", lambda _ctx, key, value: saved_state.append((key, value)))
+
+    installer.install_wiringpi(ctx)
+
+    assert run_calls[0][0][:3] == ["git", "clone", installer.WIRINGPI_REPO_URL]
+    assert run_calls[0][0][3].endswith("/WiringPi")
+    assert run_calls[1][0] == ["./build"]
+    assert run_calls[1][1]["use_sudo"] is True
+    assert run_calls[1][1]["cwd"].name == "WiringPi"
+    assert saved_state == [("wiringpi", "ok")]


### PR DESCRIPTION
## Summary\n- add WiringPi installation into installer install/repair flow on Linux\n- add tests for WiringPi install behavior\n- document installer-managed WiringPi setup for 12.48" display users\n\n## Notes\n- installs WiringPi unconditionally on Linux to avoid missed 12.48" setup steps