### PR TITLE
Expose Web UI on LAN by default

### DIFF
--- a/.github/workflows/update-os.yml
+++ b/.github/workflows/update-os.yml
@@ -141,7 +141,7 @@ jobs:
             Group=inky
             WorkingDirectory=/home/inky/Inkycal
             Environment=PYTHONUNBUFFERED=1
-            Environment=INKYCAL_WEBUI_HOST=127.0.0.1
+            Environment=INKYCAL_WEBUI_HOST=0.0.0.0
             Environment=INKYCAL_WEBUI_PORT=8080
             ExecStart=/home/inky/Inkycal/venv/bin/python /home/inky/Inkycal/inky_webui.py
             Restart=always

--- a/docs/docs/webui.md
+++ b/docs/docs/webui.md
@@ -37,19 +37,19 @@ That service runs `inky_webui.py`, which starts the lightweight HTTP server impl
 
 ## Default address
 
-By default the web UI listens on:
+By default the web UI listens on all interfaces and is reachable from your LAN at:
 
 ```text
-http://127.0.0.1:8080
+http://inkycal.local:8080
 ```
 
-Many users expose it on the Pi's local network through the installer-managed service configuration.
+If mDNS is unavailable in your network/VPN setup, use the device IP instead (for example `http://192.168.x.x:8080`).
 
 ## Important environment variables
 
 | Variable | Purpose | Default |
 |---|---|---|
-| `INKYCAL_WEBUI_HOST` | Bind address | `127.0.0.1` |
+| `INKYCAL_WEBUI_HOST` | Bind address | `0.0.0.0` |
 | `INKYCAL_WEBUI_PORT` | HTTP port | `8080` |
 | `INKYCAL_SERVICE_NAME` | Main service controlled by UI | `inkycal.service` |
 | `INKYCAL_PYTHON_BIN` | Python interpreter used for actions | `venv/bin/python` |

--- a/inkycal/utils/pisugar.py
+++ b/inkycal/utils/pisugar.py
@@ -15,7 +15,7 @@ class PiSugar:
 
     def __init__(self):
         # replace "command" with actual command
-        self.command_template = 'echo "command" | nc -q 0 127.0.0.1 8423'
+        self.command_template = 'echo "command" | nc -q 0 localhost 8423'
         self.allowed_commands = ["get battery", "get model", "get rtc_time", "get rtc_alarm_enabled",
                                  "get rtc_alarm_time", "get alarm_repeat", "rtc_pi2rtc", "rtc_alarm_set"]
 
@@ -143,5 +143,4 @@ class PiSugar:
             if status == "done":
                 return True
         return False
-
 

--- a/inkycal/webui.py
+++ b/inkycal/webui.py
@@ -26,7 +26,7 @@ from inkycal.utils.functions import get_inkycal_version
 settings = Settings()
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 SERVICE_NAME = os.getenv("INKYCAL_SERVICE_NAME", "inkycal.service")
-WEBUI_HOST = os.getenv("INKYCAL_WEBUI_HOST", "127.0.0.1")
+WEBUI_HOST = os.getenv("INKYCAL_WEBUI_HOST", "0.0.0.0")
 WEBUI_PORT = int(os.getenv("INKYCAL_WEBUI_PORT", "8080"))
 PAYPAL_URL = os.getenv("INKYCAL_PAYPAL_URL", "https://www.paypal.com/paypalme/Aceinnolab")
 HARDWARE_REFRESH_SECONDS = int(os.getenv("INKYCAL_WEBUI_HW_REFRESH_SECONDS", "10"))

--- a/installer.py
+++ b/installer.py
@@ -589,10 +589,7 @@ def run_menu(ctx: InstallerContext) -> None:
         ("Update Inkycal", lambda: update_inkycal(ctx)),
         (
             "Install / Refresh services",
-            lambda: install_services(
-                ctx,
-                ["127.0.0.1", "0.0.0.0"][choose_option("Web UI bind host", ["127.0.0.1 (localhost only)", "0.0.0.0 (LAN exposed)"])],
-            ),
+            lambda: install_services(ctx, "0.0.0.0"),
         ),
         ("Configure Pi Zero swap", lambda: setup_swap(ctx, prompt=True)),
         ("Full wipe", lambda: full_wipe(ctx)),


### PR DESCRIPTION
## Summary\n- make local web UI bind to LAN interfaces by default\n- remove localhost-only installer option and always install LAN-exposed web UI service\n- update web UI docs to use inkycal.local with IP fallback\n- replace remaining 127.0.0.1 usage with localhost in PiSugar helper\n\n## Notes\n- This fixes local network access via inkycal.local:8080 / device IP:8080 on Inkycal OS images.